### PR TITLE
Update Exchange.sol

### DIFF
--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -221,6 +221,7 @@ contract Exchange is Ownable, Pausable, ReentrancyGuard {
           if (newPrice > oldPrice) {
             reward = (rounds[i].bearAmount * (newPrice - oldPrice)) / oldPrice/24;
             if (
+            //see main comment
               collateral[ETHER][rounds[i].bearAddress] - reward <
               collateral[ETHER][rounds[i].bearAddress] / 2
             ) {


### PR DESCRIPTION
I dont understand line 224:   collateral[ETHER][rounds[i].bearAddress] - reward <
              collateral[ETHER][rounds[i].bearAddress] / 2
So if the rewards are more than 50% of the collateral it no longer liquidates?
Perhaps some liquidation logic here that add the address to the list of adresses that can be (partially) liquidated.